### PR TITLE
🐛Fix async discovery

### DIFF
--- a/src/extension_bootstrapper.ts
+++ b/src/extension_bootstrapper.ts
@@ -90,12 +90,17 @@ export class ExtensionBootstrapper {
     }
   }
 
-  protected _discoverExtensions(): Promise<Array<IExtension>> {
+  protected async _discoverExtensions(): Promise<Array<IExtension>> {
     const discoveredExtensionKeys: Array<string> = this.container.getKeysByTags(this.extensionDiscoveryTag);
+    
+    const instances: Array<any> = [];
+    
+    for (const registrationKey of discoveredExtensionKeys) {
+      const instance: any = await this.container.resolveAsync<IExtension>(registrationKey);
+      instances.push(instance);
+    }
 
-    return Promise.all(discoveredExtensionKeys.map((extensionKey: string) => {
-      return this.container.resolveAsync<IExtension>(extensionKey);
-    }));
+    return instances;
   }
 
   private async invokeAsPromiseIfPossible(functionToInvoke: any, invocationContext: any, invocationParameter?: Array<any>): Promise<any> {


### PR DESCRIPTION
This PR fixes a runtime issue that can occur due to multiple async operations running in parallel.

The issue originally was reported here: https://github.com/5minds/addict-ioc/issues/71

Due to the implementation of addict-ioc@2 the singleton cache behavior doesn't fully cover parallel async resolution. Because of this we have to ensure that the first resolution is finished before the second resolution starts.

---

**Changes:**

1. Refactored the discovery to use a `for...of` loop instead of `Promise.all` so that it runs the resolutions sequentially.

PR: #7

---

## How can others test the changes?

Run the example mentioned in https://github.com/5minds/addict-ioc/issues/71

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).

## Example

<details>
<summary>
:warning: Before merging please click here to expand and follow the guide.
</summary>
<br>

Please use `:twisted_rightwards_arrows:` at the beginning of your merge commit title.

Example 1:

<pre>
<code>
:twisted_rightwards_arrows: :bug: Fix Wrong Text Decoration at ...
</code>
</pre>

To get your commit message, just copy the first part of this pull request.

Example 2:
<pre>
<code>
**Changes:**

- Fixes Wrong Text Decoration at ...
- Fixes some typos
- ...

**Issues:**

Closes #NumberOfFixedIssue

PR: #NumberOfThisPR
</code>
</pre>
</details>

## Emojis

<details>
<summary>
Expand for a list of most used Emojis.
</summary>
<br>

Please prefix your commit messages with an Emoji.

Ref: https://gitmoji.carloscuesta.me/

| Description              | Glyphe               | Emoji  |
|--------------------------|----------------------|--------|
| Bugfix                   | `:bug:`              | 🐛     |
| Fixing Security Issues   | `:lock:`             | 🔒     |
| Configuration releated   | `:wrench:`           | 🔧     |
| Cosmetic                 | `:lipstick:`         | 💄     |
| Dependencies Downgrade   | `:arrow_down:`       | ⬇️     |
| Dependencies Upgrade     | `:arrow_up:`         | ⬆️     |
| Formatting               | `:art:`              | 🎨     |
| Improving Performance    | `:zap:`              | ⚡️      |
| Initial commit           | `:tada:`             | 🎉     |
| Linter                   | `:rotating_light:`   | 🚨     |
| Miscellaneous            | `:package:`          | 📦     |
| New Feature              | `:sparkles:`         | ✨     |
| Refactoring Code         | `:recycle:`          | ♻️      |
| Releasing / Version tags | `:bookmark:`         | 🔖     |
| Removing Stuff           | `:fire:`             | 🔥     |
| Tests                    | `:white_check_mark:` | ✅     |
| Work In Progress (WIP)   | `:construction:`     | 🚧     |

</details>
